### PR TITLE
Remove WriteLine in lowerer

### DIFF
--- a/Alto/CodeAnalysis/Lowering/Lowerer.cs
+++ b/Alto/CodeAnalysis/Lowering/Lowerer.cs
@@ -24,7 +24,6 @@ namespace Alto.CodeAnalysis.Lowering
 
         public static BoundBlockStatement Lower(BoundStatement statement)
         {
-            Console.WriteLine(statement.Kind.ToString());
             var lowerer = new Lowerer();
             var result = lowerer.RewriteStatement(statement);
             var flat = Flatten(result);


### PR DESCRIPTION
No breaking changes just removes an unnecessary WriteLine in the lowerer.